### PR TITLE
Include the setting of `ExecutionPolicy` in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,20 @@ also:
 After cloning the source code from GitHub, follow the steps below:
 
 1. Install the [.NET 6.0 SDK](https://dotnet.microsoft.com/download).
-2. Open a PowerShell prompt and build the project
+2. Open a PowerShel prompt and enable it for your user account;
+  
+   ```powershell
+   Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+   ```
+
+3. Open a PowerShell prompt and build the project
 
     ```powershell
     cd .\totalmix-volume-control
     .\build.ps1 --target Distribute --configuration Release
     ```
 
-3. You'll now find an installer under the **artifacts** sub-directory
+4. You'll now find an installer under the **artifacts** sub-directory
 
 ## Building the Icon
 


### PR DESCRIPTION
I found that on my machine I had to go digging and found in the [Scoop docs](https://github.com/ScoopInstaller/Scoop#requirements) that there is mention of performing the following;

```
PowerShell must be enabled for your user account e.g. Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
```

This then allowed me to run `build.ps1` - prior to that I was getting an error;

```
...
...
\build.ps1 is not digitally signed. You cannot run this script on the current system.
...
...
```

When I executed PowerShell as admin, or as follows, I was able to run `build.ps1`.

```
powershell.exe -executionpolicy bypass -file .\build.ps1 --target Distribute --configuration Release
```

I then opened up PowerShell as in non-admin mode and ran the `Set-ExecutionPolicy` which (I believe) then allowed me to run `build.ps1` as mentioned in the docs.

Not sure it's a great idea to include their instructions in the instructions for totalmix-volume-control (ie. what if their instructions change?) but it will likely save someone time. 

Another approach would just be to link off to the Scoop requirements.